### PR TITLE
Fix a few example scenes

### DIFF
--- a/examples/Pendulum1.py
+++ b/examples/Pendulum1.py
@@ -39,11 +39,6 @@ class PendulumController(Sofa.Core.Controller):
 		file2.write(str(0.0)+' '+str(self.node.RungeKutta.Particles.position.value[1][2])+'\n')
 		file2.close()
 
-
-		file3 = open(f"{path}HHT.txt","w")
-		file3.write(str(0.0)+' '+str(self.node.HHT.Particles.position.value[1][2])+'\n')
-		file3.close()
-
 		file4 = open(f"{path}Newmark.txt","w")
 		file4.write(str(0.0)+' '+str(self.node.Newmark.Particles.position.value[1][2])+'\n')
 		file4.close()
@@ -68,11 +63,6 @@ class PendulumController(Sofa.Core.Controller):
 		file2 = open(f"{path}RungeKutta.txt","a")
 		file2.write(str(self.time)+' '+str(self.node.RungeKutta.Particles.position.value[1][2])+'\n')
 		file2.close()
-
-
-		file3 = open(f"{path}HHT.txt","a")
-		file3.write(str(self.time)+' '+str(self.node.HHT.Particles.position.value[1][2])+'\n')
-		file3.close()
 
 		file4 = open(f"{path}Newmark.txt","a")
 		file4.write(str(self.time)+' '+str(self.node.Newmark.Particles.position.value[1][2])+'\n')
@@ -124,16 +114,6 @@ def createScene(rootNode):
 
 	RK = rootNode.addChild("RungeKutta")
 	RK.addObject('RungeKutta4Solver', name="Solver")
-	RK.addObject('CGLinearSolver', name="CG Solver", iterations="25", tolerance="1e-10", threshold="1e-10")
-	RK.addObject('MechanicalObject', name="Particles", template="Vec3d",position="0 0 0 1 0 0", velocity="0 0 0 0 0 0", showObject = True, showObjectScale = 10)
-	RK.addObject('UniformMass', name="Mass", totalMass="0.1")
-	RK.addObject('FixedConstraint', indices="0")
-	RK.addObject('StiffSpringForceField', name="Springs", spring="0 1 100 0.0 1")
-	# RK.addObject('SphereCollisionModel', radius="0.1")
-
-
-	RK = rootNode.addChild("HHT")
-	RK.addObject('HHTSolver', name="Solver")
 	RK.addObject('CGLinearSolver', name="CG Solver", iterations="25", tolerance="1e-10", threshold="1e-10")
 	RK.addObject('MechanicalObject', name="Particles", template="Vec3d",position="0 0 0 1 0 0", velocity="0 0 0 0 0 0", showObject = True, showObjectScale = 10)
 	RK.addObject('UniformMass', name="Mass", totalMass="0.1")

--- a/examples/creep-test.py
+++ b/examples/creep-test.py
@@ -63,6 +63,22 @@ class CylinderController(Sofa.Core.Controller):
 
 
 def createScene(rootNode):
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Constraint.Lagrangian.Solver') # Needed to use components [BlockGaussSeidelConstraintSolver]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Constraint.Projective') # Needed to use components [FixedProjectiveConstraint]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Engine.Select') # Needed to use components [BoxROI]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.IO.Mesh') # Needed to use components [MeshSTLLoader,MeshVTKLoader]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.LinearSolver.Iterative') # Needed to use components [CGLinearSolver]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Mapping.Linear') # Needed to use components [BarycentricMapping]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Mass') # Needed to use components [UniformMass]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.MechanicalLoad') # Needed to use components [ConstantForceField]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.ODESolver.Backward') # Needed to use components [EulerImplicitSolver]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.StateContainer') # Needed to use components [MechanicalObject]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Topology.Container.Dynamic') # Needed to use components [TetrahedronSetGeometryAlgorithms,TetrahedronSetTopologyContainer,TetrahedronSetTopologyModifier]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Visual') # Needed to use components [VisualStyle]
+    rootNode.addObject('RequiredPlugin', name='Sofa.GL.Component.Rendering3D') # Needed to use components [OglModel,OglSceneFrame]
+    rootNode.addObject('RequiredPlugin', name='SofaViscoElastic') # Needed to use components [TetrahedronViscoelasticityFEMForceField]
+
+
     rootNode.addObject(
         'VisualStyle',
         displayFlags='showVisualModels hideBehaviorModels hideCollisionModels '
@@ -73,7 +89,7 @@ def createScene(rootNode):
     rootNode.gravity = [0, 0, -9.81]
     rootNode.dt = 1e6 / 70e6
     rootNode.addObject('DefaultAnimationLoop', computeBoundingBox="0")
-    rootNode.addObject('GenericConstraintSolver', tolerance=1e-24, maxIterations=1000)
+    rootNode.addObject('BlockGaussSeidelConstraintSolver', tolerance=1e-24, maxIterations=1000)
     rootNode.addObject('OglSceneFrame', style='Arrows', alignment='TopRight')
 
     # --- Cylinder ---
@@ -134,8 +150,6 @@ def createScene(rootNode):
         src="@topo",
         indices='@boxToPull.indices'
     )
-
-    cylinder.addObject('GenericConstraintSolver')
 
     # Controller
     cylinder.addObject(

--- a/examples/stress-map.py
+++ b/examples/stress-map.py
@@ -96,9 +96,8 @@ def createScene(rootNode):
     # Animation / constraints loop
     rootNode.addObject("FreeMotionAnimationLoop")
 
-    # BlockGaussSeidelConstraintSolver was removed in SOFA 25.06 → use GenericConstraintSolver
     rootNode.addObject(
-        "GenericConstraintSolver",
+        "BlockGaussSeidelConstraintSolver",
         maxIterations=1e4,
         tolerance=1e-50,
     )

--- a/examples/stress-relaxation-test.py
+++ b/examples/stress-relaxation-test.py
@@ -104,9 +104,8 @@ def createScene(rootNode):
     # Animation / constraint loop
     rootNode.addObject("FreeMotionAnimationLoop")
 
-    # BlockGaussSeidelConstraintSolver was removed in SOFA 25.06 → use GenericConstraintSolver
     rootNode.addObject(
-        "GenericConstraintSolver",
+        "BlockGaussSeidelConstraintSolver",
         maxIterations=1e4,
         tolerance=1e-12,
     )

--- a/examples/stress-relaxation-viscohyperelastic.py
+++ b/examples/stress-relaxation-viscohyperelastic.py
@@ -118,9 +118,8 @@ def createScene(rootNode):
     # Animation / constraint loop
     rootNode.addObject("FreeMotionAnimationLoop")
 
-    # BlockGaussSeidelConstraintSolver was removed in SOFA 25.06 → use GenericConstraintSolver
     rootNode.addObject(
-        "GenericConstraintSolver",
+        "BlockGaussSeidelConstraintSolver",
         maxIterations=1e4,
         tolerance=1e-50,
     )

--- a/examples/volumetric_mesh.py
+++ b/examples/volumetric_mesh.py
@@ -7,17 +7,23 @@ import os
 path = os.path.dirname(os.path.abspath(__file__))+'/design/'
 
 def createScene(rootNode):
-	rootNode.addObject('RequiredPlugin' ,pluginName='SofaExporter')
+
+	rootNode.addObject('RequiredPlugin', name="CGALPlugin") # Needed to use components [MeshGenerationFromPolyhedron]
+	rootNode.addObject('RequiredPlugin', name='Sofa.Component.IO.Mesh') # Needed to use components [MeshSTLLoader,VTKExporter]
+	rootNode.addObject('RequiredPlugin', name='Sofa.Component.StateContainer') # Needed to use components [MechanicalObject]
+	rootNode.addObject('RequiredPlugin', name='Sofa.Component.Topology.Container.Constant') # Needed to use components [MeshTopology]
+	rootNode.addObject('RequiredPlugin', name='Sofa.Component.Visual') # Needed to use components [VisualStyle]
+	rootNode.addObject('RequiredPlugin', name='Sofa.GL.Component.Rendering3D') # Needed to use components [OglModel]
+
 	rootNode.addObject('VisualStyle',displayFlags="hideVisual")
-	rootNode.addObject('RequiredPlugin', pluginName="CGALPlugin")
-	rootNode.addObject('RequiredPlugin', name="SofaOpenglVisual")
+
 	rootNode.addObject('MeshSTLLoader', name="loader", filename="mesh/cylinder5296.stl")
 
 	rootNode.addObject('MechanicalObject', name="dofs", position="@loader.position")
 
 
 	rootNode.addObject('MeshGenerationFromPolyhedron', name="gen", inputPoints="@loader.position", inputTriangles="@loader.triangles",facetSize="0.2",facetApproximation="1",cellRatio="0.2", cellSize="0.25", drawTetras = 1)
-	rootNode.addObject('Mesh', name ='topo', position='@gen.outputPoints', tetrahedra='@gen.outputTetras')
+	rootNode.addObject('MeshTopology', name ='topo', position='@gen.outputPoints', tetrahedra='@gen.outputTetras')
 	rootNode.addObject('VTKExporter', filename='finger',src = '@topo', edges='0', exportAtBegin='1')
 	rootNode.addObject('OglModel', color=[0.3, 0.2, 0.2, 0.6])
 	return rootNode


### PR DESCRIPTION
This PR updates a handful of example scripts to bring them in line with SOFA 25.12. The main goals are:

- Explicit plugin loading:	All components that are now provided by separate SOFA plugins are declared with RequiredPlugin. This makes the examples runnable out‑of‑the‑box on a clean SOFA installation.
- Replace the removed GenericConstraintSolver: The old GenericConstraintSolver component was deprecated/removed in SOFA 25.12. The examples now use the new BlockGaussSeidelConstraintSolver (or, where appropriate, keep the original BlockGaussSeidelConstraintSolver that was already in use).
- Clean‑up HHTSolver unknown solver
- Duplicated plugin declarations have been removed.
- Replaced the Mesh alias with MeshTopology