### PR TITLE
[Bindings] Fix compilation for v26.06

### DIFF
--- a/Bindings/src/Binding_TetrahedronViscoElasticityFEMForceField.cpp
+++ b/Bindings/src/Binding_TetrahedronViscoElasticityFEMForceField.cpp
@@ -34,7 +34,6 @@
 
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/PythonFactory.h>
-#include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
 #include <Binding_TetrahedronViscoElasticityFEMForceField.h>
 #include <SofaViscoElastic/TetrahedronViscoelasticityFEMForceField.h>
 

--- a/Bindings/src/Binding_TetrahedronViscoHyperElasticityFEMForceField.cpp
+++ b/Bindings/src/Binding_TetrahedronViscoHyperElasticityFEMForceField.cpp
@@ -34,7 +34,6 @@
 
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/PythonFactory.h>
-#include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
 #include <Binding_TetrahedronViscoHyperElasticityFEMForceField.h>
 #include <SofaViscoElastic/TetrahedronViscoHyperelasticityFEMForceField.h>
 


### PR DESCRIPTION
The header has been renamed to Binding_BaseComponent in SofaPython3 but it is not needed anyway